### PR TITLE
Allow for Thumbnails

### DIFF
--- a/modification.js
+++ b/modification.js
@@ -24,7 +24,13 @@ let modification = (function()
 			if (!fs.existsSync(manifestPath))
 				throw Error("Can't find manifest file: " + manifestFileName)
 			
-			const manifest = JSON.parse(fs.readFileSync(manifestPath))
+			let manifest = null
+			try {
+				manifest = JSON.parse(fs.readFileSync(manifestPath))
+			} catch (error) {
+				console.error(error)
+				throw Error("Probably encountered malformed OwlcatModificationManifest.json!")
+			}
 			
 			if (!hasNotEmptyStringProperty(manifest, "UniqueName"))
 				throw Error("UniqueName is missing in manifest file " + manifestFileName)
@@ -47,6 +53,7 @@ let modification = (function()
 					Description: manifest.Description || "",
 					Author: manifest.Author || "",
 					Repository: manifest.Repository || "",
+					ImageName: manifest.ImageName || "",
 					HomePage: manifest.HomePage || "",
 					Dependencies: [], // [{Name: string, Version: string}]
 				},

--- a/renderer.js
+++ b/renderer.js
@@ -103,12 +103,16 @@ module.exports = (() => {
 			const version = (selectedModification || notSelectedModification).manifest.Version;
 			const displayName = (selectedModification || notSelectedModification).manifest.DisplayName;
 			const description = (selectedModification || notSelectedModification).manifest.Description;
+			const author = (selectedModification || notSelectedModification).manifest.Author;
+			const imagename = (selectedModification || notSelectedModification).manifest.ImageName;
 			
 			$(selectedModificationContainer).find('.modification-directory').text(directoryPath)
 			$(selectedModificationContainer).find('.modification-unique-name').text(uniqueName)
 			$(selectedModificationContainer).find('.modification-version').text(version)
 			$(selectedModificationContainer).find('.modification-display-name').text(displayName)
 			$(selectedModificationContainer).find('.modification-description').text(description)
+			$(selectedModificationContainer).find('.modification-author').text(author)
+			$(selectedModificationContainer).find('.modification-image-name').text(imagename)
 			
 			if (selectedModification == null) {
 				renderer.getWorkshopIdBlock().hide()

--- a/steam.js
+++ b/steam.js
@@ -51,18 +51,22 @@ module.exports = (() => {
 					console.log('Archived: total bytes ' + archive.pointer() + ', ' + tempFilePath);
 
 					try {
+						let imagePath = ""
+						if (modification.manifest.ImageName) 
+							imagePath = modification.path + "\\" + modification.manifest.ImageName
 						if (modification.workshopId == null) {
 							greenworks.ugcPublish(
 								tempFilePath,
 								modification.manifest.DisplayName,
 								modification.manifest.Description,
-								"", success, fail, progress)
+								imagePath,
+								success, fail, progress)
 						} else {
 							greenworks.updatePublishedWorkshopFile(
 								{tags: []},
 								modification.workshopId,
 								tempFilePath,
-								"",
+								imagePath,
 								modification.manifest.DisplayName,
 								modification.manifest.Description, success, fail, progress)
 						}
@@ -130,11 +134,16 @@ module.exports = (() => {
 				return (results) =>
 				{
 					results.forEach(i => {
-						const folderPath = greenworks.ugcGetItemInstallInfo(i.publishedFileId).folder
-						items.push({
-							id: i.publishedFileId,
-							path: folderPath
-						})
+						// Returns undefined if the information could not be fetched
+						const itemInfo = greenworks.ugcGetItemInstallInfo(i.publishedFileId)
+						if (typeof itemInfo !== "undefined")
+						{
+							const folderPath = itemInfo.folder
+							items.push({
+								id: i.publishedFileId,
+								path: folderPath
+							})
+						}
 					})
 	
 					if (results.length > 0) {

--- a/view/index.html
+++ b/view/index.html
@@ -96,6 +96,22 @@
                             <span class="modification-description">none</span>
                         </td>
                     </tr>
+                    <tr>
+                        <td class="col-3 m-1">
+                            Author:
+                        </td>
+                        <td class="col m-1">
+                            <span class="modification-author">none</span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="col-3 m-1">
+                            Image Name:
+                        </td>
+                        <td class="col m-1">
+                            <span class="modification-image-name">none</span>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
             <div class="input-group mb-3" id="modification-workshop-id">


### PR DESCRIPTION
- Allow for Thumbnails (the current implementation will include the thumbnail in the shipped package; I don't know whether that should be fixed?
- Display Author and Thumbnails on the Publish Page
![grafik](https://github.com/OwlcatOpenSource/OwlcatRogueTraderSteamworkshop/assets/62178123/889e6b7c-fed7-4a14-b819-8d6e83a89db1)
- Handle a critical error where ugcGetItemInstallInfo returned undefined on application start which basically made the application unusable